### PR TITLE
ルーティングによる画面遷移機能の開発

### DIFF
--- a/profit-system/src/components/organisms/Sidebar.tsx
+++ b/profit-system/src/components/organisms/Sidebar.tsx
@@ -10,6 +10,7 @@ export const Sidebar: FC = memo(() => {
       <Flex
         direction="column"
         maxW="256px"
+        w="256px"
         backgroundColor="orange.50"
         height="100vh"
         fontWeight="600"

--- a/profit-system/src/components/pages/Log.tsx
+++ b/profit-system/src/components/pages/Log.tsx
@@ -1,13 +1,11 @@
 import { FC, memo } from "react";
-import { Sidebar } from "../organisms/Sidebar";
 import { PrimaryButton } from "../atoms/button/PrimaryButton";
 
 export const Log: FC = memo(() => {
-    return (
-      <>
-        <Sidebar />
-        <p>ログページです</p>;
-        <PrimaryButton Text="登録" />
-      </>
-    );
-  });
+  return (
+    <>
+      <p>ログページです</p>;
+      <PrimaryButton Text="登録" />
+    </>
+  );
+});

--- a/profit-system/src/components/pages/WorkhourEdit.tsx
+++ b/profit-system/src/components/pages/WorkhourEdit.tsx
@@ -1,0 +1,5 @@
+import { memo, FC } from "react";
+
+export const WorkhourRegister: FC = memo(() => {
+  return <p>工数編集画面です</p>;
+});

--- a/profit-system/src/components/pages/WorkhourEdit.tsx
+++ b/profit-system/src/components/pages/WorkhourEdit.tsx
@@ -1,5 +1,5 @@
 import { memo, FC } from "react";
 
-export const WorkhourRegister: FC = memo(() => {
+export const WorkhourEdit: FC = memo(() => {
   return <p>工数編集画面です</p>;
 });

--- a/profit-system/src/components/pages/WorkhourRegister.tsx
+++ b/profit-system/src/components/pages/WorkhourRegister.tsx
@@ -1,0 +1,5 @@
+import { memo, FC } from "react";
+
+export const WorkhourRegister: FC = memo(() => {
+  return <p>工数登録画面です</p>;
+});

--- a/profit-system/src/components/templates/MainTemplate.tsx
+++ b/profit-system/src/components/templates/MainTemplate.tsx
@@ -1,5 +1,6 @@
 import { memo, FC, ReactNode } from "react";
 import { Sidebar } from "../organisms/Sidebar";
+import { Flex } from "@chakra-ui/react";
 
 type Props = {
   children: ReactNode;
@@ -10,9 +11,11 @@ export const MainTemplate: FC<Props> = memo((props) => {
 
   return (
     <>
-      {/* <Header /> */}
-      <Sidebar />
-      {children}
+      <Flex>
+        {/* <Header /> */}
+        <Sidebar />
+        {children}
+      </Flex>
     </>
   );
 });

--- a/profit-system/src/router/HomeRoutes.tsx
+++ b/profit-system/src/router/HomeRoutes.tsx
@@ -1,8 +1,18 @@
-import { Login } from "../components/pages/Login";
+import { Log } from "../components/pages/Log";
+import { WorkhourEdit } from "../components/pages/WorkhourEdit";
+import { WorkhourRegister } from "../components/pages/WorkhourRegister";
 
 export const homeRoutes = [
-    {
-        path: "/",
-        element: <Login /> 
-    },
+  {
+    path: "/log",
+    element: <Log />,
+  },
+  {
+    path: "/workhour_register",
+    element: <WorkhourRegister />,
+  },
+  {
+    path: "/workhour_edit",
+    element: <WorkhourEdit />,
+  },
 ];

--- a/profit-system/src/router/Router.tsx
+++ b/profit-system/src/router/Router.tsx
@@ -1,14 +1,20 @@
 import { FC, memo } from "react";
 import { Route, Routes } from "react-router-dom";
 import { Login } from "../components/pages/Login";
-import { Log } from "../components/pages/Log";
-
+import { homeRoutes } from "./HomeRoutes";
+import { MainTemplate } from "../components/templates/MainTemplate";
 
 export const Router: FC = memo(() => {
-    return(
-        <Routes>
-            <Route path="/" element={<Login />} />
-            <Route path="/log" element={<Log />} />
-        </Routes>
-    );
+  return (
+    <Routes>
+      <Route path="/" element={<Login />} />
+      {homeRoutes.map((route) => (
+        <Route
+          key={route.path}
+          path={route.path}
+          element={<MainTemplate>{route.element}</MainTemplate>}
+        />
+      ))}
+    </Routes>
+  );
 });


### PR DESCRIPTION
## Why
#39 

## What
- pagesディレクトリに工数登録・編集画面を作成。
- HomeRoutesファイルに工数登録・編集情報をテスト用で追加。
- HomeRoutesの配列にmap関数を使って各ページのルーティング完了。
- map関数を使用する時にMainTemplateを追加して、各ページにSidebarが表示される。
- MainTemplateにFlexコンポーネントを追加。（コンポーネントがサイドバーの右側に配置できるようになる）
- ログ画面から不要なコンポーネントを削除。

残り：
- 全ページの作成。
- サイドバーからの画面遷移。

ログ画面：
![image](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/f36ef786-5ad8-4ad7-b2f8-fa667ed0788f)

工数登録画面：
![image](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/814e731d-b44b-43cc-975a-41d5f845f9f5)
