### PR TITLE
顧客一覧画面にCompanyテーブルのデータを表示する

### DIFF
--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -1,10 +1,29 @@
 import { Table, TableContainer, Tbody, Thead, Tr } from "@chakra-ui/react";
-import { memo, FC } from "react";
+import { memo, FC, useState, useEffect } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
+import { DocumentData, collection, doc, getDocs } from "firebase/firestore";
+import { db } from "../../../firebase";
 
 export const CompaniesTableTemplateList: FC = memo(() => {
+  const [companyData, setCompanyData] = useState<DocumentData>([]);
+
+  useEffect(() => {
+    const getCompanyData = async () => {
+      const companyList: DocumentData[] = [];
+      const querySnapshot = await getDocs(collection(db, "company"));
+      querySnapshot.forEach((doc) => {
+        companyList.push(doc.data());
+        // console.log(doc.data());
+        console.log(doc.id);
+      });
+      setCompanyData(companyList);
+    };
+    getCompanyData();
+  }, []);
+  console.log(companyData);
+
   return (
     <TableContainer>
       <Table variant="simple" border="none">
@@ -32,6 +51,15 @@ export const CompaniesTableTemplateList: FC = memo(() => {
             <TableBodyItem text="03-0000-0000" />
             <EditItem />
           </Tr>
+          {companyData.map((data: DocumentData) => (
+            <Tr fontSize="14" key={data.name}>
+              <TableBodyItem text={data.name} />
+              <TableBodyItem text={data.postCode} />
+              <TableBodyItem text={data.address} />
+              <TableBodyItem text={data.phone} />
+              <EditItem />
+            </Tr>
+          ))}
         </Tbody>
       </Table>
     </TableContainer>

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -3,7 +3,7 @@ import { memo, FC, useState, useEffect } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
-import { DocumentData, collection, doc, getDocs } from "firebase/firestore";
+import { DocumentData, collection, getDocs } from "firebase/firestore";
 import { db } from "../../../firebase";
 
 export const CompaniesTableTemplateList: FC = memo(() => {

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -15,14 +15,11 @@ export const CompaniesTableTemplateList: FC = memo(() => {
       const querySnapshot = await getDocs(collection(db, "company"));
       querySnapshot.forEach((doc) => {
         companyList.push(doc.data());
-        // console.log(doc.data());
-        console.log(doc.id);
       });
       setCompanyData(companyList);
     };
     getCompanyData();
   }, []);
-  console.log(companyData);
 
   return (
     <TableContainer>

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -34,20 +34,6 @@ export const CompaniesTableTemplateList: FC = memo(() => {
           </Tr>
         </Thead>
         <Tbody alignItems="center">
-          <Tr fontSize="14">
-            <TableBodyItem text="株式会社A" />
-            <TableBodyItem text="611-0000" />
-            <TableBodyItem text="東京都葛飾区〇〇町3丁目23-55" />
-            <TableBodyItem text="03-0000-0000" />
-            <EditItem />
-          </Tr>
-          <Tr fontSize="14">
-            <TableBodyItem text="株式会社B" />
-            <TableBodyItem text="611-0000" />
-            <TableBodyItem text="東京都品川区〇〇町5丁目23-69" />
-            <TableBodyItem text="03-0000-0000" />
-            <EditItem />
-          </Tr>
           {companyData.map((data: DocumentData) => (
             <Tr fontSize="14" key={data.name}>
               <TableBodyItem text={data.name} />


### PR DESCRIPTION
## why
#29 

## what
- Companyコレクションにあるデータを配列に入れ、map関数を使ってコンポーネントのレンダリングを行いました。

## Problem:
- 各ドキュメントのデータを取得できてコンポーネントのレンダリングを行いましたが、ドキュメントのIDが編集画面に必要と思いましてテストをやっています。

## Possible Solution:
- 登録の際に、各顧客データに　id: "docの文字列ID”を追記する。

現在のスクショ：
![image](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/513499e9-1afb-45e8-bb0a-2f0a830440ee)


## related issues
close #n