### PR TITLE
顧客編集画面の情報をCompanyテーブルに更新する機能を開発

### DIFF
--- a/profit-system/src/components/atoms/button/SecondaryButton.tsx
+++ b/profit-system/src/components/atoms/button/SecondaryButton.tsx
@@ -5,10 +5,11 @@ type Props = {
   text: string;
   size?: string;
   px?: string;
+  onClick?: () => void;
 };
 
 export const SecondaryButton: FC<Props> = memo((props) => {
-  const { text, size, px } = props;
+  const { text, size, px, onClick } = props;
   return (
     <Button
       bg="white"
@@ -20,6 +21,7 @@ export const SecondaryButton: FC<Props> = memo((props) => {
       variant="outline"
       borderColor="black"
       _hover={{ opacity: 0.8 }}
+      onClick={onClick}
     >
       {text}
     </Button>

--- a/profit-system/src/components/molecules/EditItem.tsx
+++ b/profit-system/src/components/molecules/EditItem.tsx
@@ -2,7 +2,12 @@ import { Box, Td } from "@chakra-ui/react";
 import { FC } from "react";
 import { SecondaryButton } from "../atoms/button/SecondaryButton";
 
-export const EditItem: FC = () => {
+type Props = {
+  onClick?: () => void;
+};
+
+export const EditItem: FC<Props> = (props) => {
+  const { onClick } = props;
   return (
     <Td
       border="none"
@@ -11,7 +16,7 @@ export const EditItem: FC = () => {
       alignItems="center"
     >
       <Box display="flex" justifyContent="center" alignItems="center" pt="2.5">
-        <SecondaryButton text="編集" size="sm" />
+        <SecondaryButton text="編集" size="sm" onClick={onClick} />
       </Box>
     </Td>
   );

--- a/profit-system/src/components/molecules/container/FormButtonContainer.tsx
+++ b/profit-system/src/components/molecules/container/FormButtonContainer.tsx
@@ -7,15 +7,26 @@ type Props = {
   secondaryPx?: string;
   ml?: string;
   primaryText?: string;
-  onClick?: () => void;
+  primaryOnClick?: () => void;
+  secondaryOnClick?: () => void;
 };
 
 export const FormButtonContainer: FC<Props> = memo((props) => {
-  const { secondaryPx, ml, primaryText = "登録", onClick } = props;
+  const {
+    secondaryPx,
+    ml,
+    primaryText = "登録",
+    primaryOnClick,
+    secondaryOnClick,
+  } = props;
   return (
     <Flex justifyContent="center" alignItems="center" gap="50px" ml={ml}>
-      <SecondaryButton text="一覧に戻る" px={secondaryPx} />
-      <PrimaryButton text={primaryText} onClick={onClick} />
+      <SecondaryButton
+        text="一覧に戻る"
+        px={secondaryPx}
+        onClick={secondaryOnClick}
+      />
+      <PrimaryButton text={primaryText} onClick={primaryOnClick} />
     </Flex>
   );
 });

--- a/profit-system/src/components/molecules/item/PhoneFormItem.tsx
+++ b/profit-system/src/components/molecules/item/PhoneFormItem.tsx
@@ -5,10 +5,20 @@ type Props = {
   handleValueChange1?: (value: string) => void;
   handleValueChange2?: (value: string) => void;
   handleValueChange3?: (value: string) => void;
+  value1?: string;
+  value2?: string;
+  value3?: string;
 };
 
 export const PhoneFormItem: FC<Props> = memo((props) => {
-  const { handleValueChange1, handleValueChange2, handleValueChange3 } = props;
+  const {
+    handleValueChange1,
+    handleValueChange2,
+    handleValueChange3,
+    value1,
+    value2,
+    value3,
+  } = props;
 
   const handlePhoneChange1 = (e: ChangeEvent<HTMLInputElement>) => {
     const value1 = e.target.value;
@@ -36,11 +46,26 @@ export const PhoneFormItem: FC<Props> = memo((props) => {
         電話番号
       </FormLabel>
       <Flex>
-        <Input mx="18px" w="70px" onChange={handlePhoneChange1} />
+        <Input
+          mx="18px"
+          w="70px"
+          onChange={handlePhoneChange1}
+          value={value1}
+        />
         <Text fontSize="2xl">-</Text>
-        <Input mx="18px" w="100px" onChange={handlePhoneChange2} />
+        <Input
+          mx="18px"
+          w="100px"
+          onChange={handlePhoneChange2}
+          value={value2}
+        />
         <Text fontSize="2xl">-</Text>
-        <Input mx="18px" w="100px" onChange={handlePhoneChange3} />
+        <Input
+          mx="18px"
+          w="100px"
+          onChange={handlePhoneChange3}
+          value={value3}
+        />
       </Flex>
     </Flex>
   );

--- a/profit-system/src/components/molecules/item/PostNumFormItem.tsx
+++ b/profit-system/src/components/molecules/item/PostNumFormItem.tsx
@@ -5,6 +5,8 @@ import { memo, FC, ChangeEvent } from "react";
 type Props = {
   handleValueChange1?: (value: string) => void;
   handleValueChange2?: (value: string) => void;
+  value1?: string;
+  value2?: string;
 };
 
 const PostIcon = createIcon({
@@ -14,7 +16,7 @@ const PostIcon = createIcon({
 });
 
 export const PostNumFormItem: FC<Props> = memo((props) => {
-  const { handleValueChange1, handleValueChange2 } = props;
+  const { handleValueChange1, handleValueChange2, value1, value2 } = props;
 
   const handlePostChange1 = (e: ChangeEvent<HTMLInputElement>) => {
     const value1 = e.target.value;
@@ -39,9 +41,19 @@ export const PostNumFormItem: FC<Props> = memo((props) => {
       </FormLabel>
       <Flex alignItems="center">
         <PostIcon color="blackAlpha.500" />
-        <Input mx="18px" w="150px" onChange={handlePostChange1} />
+        <Input
+          mx="18px"
+          w="150px"
+          onChange={handlePostChange1}
+          value={value1}
+        />
         <Text fontSize="2xl">-</Text>
-        <Input mx="18px" w="150px" onChange={handlePostChange2} />
+        <Input
+          mx="18px"
+          w="150px"
+          onChange={handlePostChange2}
+          value={value2}
+        />
       </Flex>
     </Flex>
   );

--- a/profit-system/src/components/molecules/item/PrimaryFormItem.tsx
+++ b/profit-system/src/components/molecules/item/PrimaryFormItem.tsx
@@ -4,10 +4,11 @@ import { memo, FC, ChangeEvent } from "react";
 type Props = {
   text: string;
   handleValueChange?: (value: string) => void;
+  value?: string;
 };
 
 export const PrimaryFormItem: FC<Props> = memo((props) => {
-  const { text, handleValueChange } = props;
+  const { text, handleValueChange, value } = props;
 
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -27,7 +28,7 @@ export const PrimaryFormItem: FC<Props> = memo((props) => {
         {text}
       </FormLabel>
       <Flex>
-        <Input w="400px" onChange={handleInputChange} />
+        <Input w="400px" onChange={handleInputChange} value={value} />
       </Flex>
     </Flex>
   );

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -3,7 +3,7 @@ import { memo, FC, useState, useEffect } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
-import { DocumentData, collection, getDocs } from "firebase/firestore";
+import { collection, getDocs } from "firebase/firestore";
 import { db } from "../../../firebase";
 import { useNavigate } from "react-router-dom";
 
@@ -36,7 +36,6 @@ export const CompaniesTableTemplateList: FC = memo(() => {
     };
     getCompanyData();
   }, []);
-  console.log(companyData);
 
   const onClickEdit = (docId: string) => {
     navigate("/companies_list/company_edit", {
@@ -59,7 +58,7 @@ export const CompaniesTableTemplateList: FC = memo(() => {
           </Tr>
         </Thead>
         <Tbody alignItems="center">
-          {companyData.map((data: DocumentData) => (
+          {companyData.map((data) => (
             <Tr fontSize="14" key={data.id}>
               <TableBodyItem text={data.name} />
               <TableBodyItem text={data.postCode} />

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -48,20 +48,6 @@ export const CompaniesTableTemplateList: FC = memo(() => {
           </Tr>
         </Thead>
         <Tbody alignItems="center">
-          <Tr fontSize="14">
-            <TableBodyItem text="株式会社A" />
-            <TableBodyItem text="611-0000" />
-            <TableBodyItem text="東京都葛飾区〇〇町3丁目23-55" />
-            <TableBodyItem text="03-0000-0000" />
-            <EditItem />
-          </Tr>
-          <Tr fontSize="14">
-            <TableBodyItem text="株式会社B" />
-            <TableBodyItem text="611-0000" />
-            <TableBodyItem text="東京都品川区〇〇町5丁目23-69" />
-            <TableBodyItem text="03-0000-0000" />
-            <EditItem />
-          </Tr>
           {companyData.map((data: DocumentData) => (
             <Tr fontSize="14" key={data.id}>
               <TableBodyItem text={data.name} />

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -37,10 +37,20 @@ export const CompaniesTableTemplateList: FC = memo(() => {
     getCompanyData();
   }, []);
 
-  const onClickEdit = (docId: string) => {
+  const onClickEdit = (
+    docId: string,
+    name: string,
+    postCode: string,
+    address: string,
+    phone: string
+  ) => {
     navigate("/companies_list/company_edit", {
       state: {
         docId: docId,
+        name: name,
+        postCode: postCode,
+        address: address,
+        phone: phone,
       },
     });
   };
@@ -64,7 +74,17 @@ export const CompaniesTableTemplateList: FC = memo(() => {
               <TableBodyItem text={data.postCode} />
               <TableBodyItem text={data.address} />
               <TableBodyItem text={data.phone} />
-              <EditItem onClick={() => onClickEdit(data.id)} />
+              <EditItem
+                onClick={() =>
+                  onClickEdit(
+                    data.id,
+                    data.name,
+                    data.postCode,
+                    data.address,
+                    data.phone
+                  )
+                }
+              />
             </Tr>
           ))}
         </Tbody>

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -1,10 +1,40 @@
 import { Table, TableContainer, Tbody, Thead, Tr } from "@chakra-ui/react";
-import { memo, FC } from "react";
+import { memo, FC, useState, useEffect } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
+import { DocumentData, collection, getDocs } from "firebase/firestore";
+import { db } from "../../../firebase";
+import { useNavigate } from "react-router-dom";
 
 export const CompaniesTableTemplateList: FC = memo(() => {
+  const navigate = useNavigate();
+  const [companyData, setCompanyData] = useState<DocumentData>([]);
+
+  useEffect(() => {
+    const getCompanyData = async () => {
+      const companyList: DocumentData[] = [];
+      const querySnapshot = await getDocs(collection(db, "company"));
+      querySnapshot.forEach((doc) => {
+        const dataId = {
+          id: doc.id,
+        };
+        companyList.push({ ...dataId, ...doc.data() });
+      });
+      setCompanyData(companyList);
+    };
+    getCompanyData();
+  }, []);
+  console.log(companyData);
+
+  const onClickEdit = (docId: string) => {
+    navigate("/companies_list/company_edit", {
+      state: {
+        docId: docId,
+      },
+    });
+  };
+
   return (
     <TableContainer>
       <Table variant="simple" border="none">
@@ -32,6 +62,15 @@ export const CompaniesTableTemplateList: FC = memo(() => {
             <TableBodyItem text="03-0000-0000" />
             <EditItem />
           </Tr>
+          {companyData.map((data: DocumentData) => (
+            <Tr fontSize="14" key={data.id}>
+              <TableBodyItem text={data.name} />
+              <TableBodyItem text={data.postCode} />
+              <TableBodyItem text={data.address} />
+              <TableBodyItem text={data.phone} />
+              <EditItem onClick={() => onClickEdit(data.id)} />
+            </Tr>
+          ))}
         </Tbody>
       </Table>
     </TableContainer>

--- a/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/CompaniesTableTemplateList.tsx
@@ -7,19 +7,30 @@ import { DocumentData, collection, getDocs } from "firebase/firestore";
 import { db } from "../../../firebase";
 import { useNavigate } from "react-router-dom";
 
+type CompanyDbType = {
+  id: string;
+  name: string;
+  address: string;
+  postCode: string;
+  phone: string;
+};
+
 export const CompaniesTableTemplateList: FC = memo(() => {
   const navigate = useNavigate();
-  const [companyData, setCompanyData] = useState<DocumentData>([]);
+  const [companyData, setCompanyData] = useState<CompanyDbType[]>([]);
 
   useEffect(() => {
     const getCompanyData = async () => {
-      const companyList: DocumentData[] = [];
+      const companyList: CompanyDbType[] = [];
       const querySnapshot = await getDocs(collection(db, "company"));
       querySnapshot.forEach((doc) => {
-        const dataId = {
+        companyList.push({
           id: doc.id,
-        };
-        companyList.push({ ...dataId, ...doc.data() });
+          name: doc.data().name,
+          address: doc.data().address,
+          postCode: doc.data().postCode,
+          phone: doc.data().phone,
+        });
       });
       setCompanyData(companyList);
     };

--- a/profit-system/src/components/organisms/form/CompanyEditForm.tsx
+++ b/profit-system/src/components/organisms/form/CompanyEditForm.tsx
@@ -1,12 +1,30 @@
 import { FormControl } from "@chakra-ui/react";
-import { FC, memo } from "react";
+import { FC, memo, useEffect, useState } from "react";
 import { FormButtonContainer } from "../../molecules/container/FormButtonContainer";
 import { MainContentContainer } from "../../molecules/container/MainContentContainer";
 import { PrimaryFormItem } from "../../molecules/item/PrimaryFormItem";
 import { PostNumFormItem } from "../../molecules/item/PostNumFormItem";
 import { PhoneFormItem } from "../../molecules/item/PhoneFormItem";
+import { useLocation } from "react-router-dom";
+import { DocumentData, doc, getDoc } from "firebase/firestore";
+import { db } from "../../../firebase";
 
 export const CompanyEditForm: FC = memo(() => {
+  const location = useLocation();
+  const [companyEditData, setCompanyEditData] = useState<DocumentData>();
+  const docId = location.state.docId;
+  console.log(docId);
+
+  const companyDocRef = doc(db, "company", docId);
+  useEffect(() => {
+    const getCompanyEditData = async () => {
+      const companyDocSnap = await getDoc(companyDocRef);
+      console.log(companyDocSnap.data());
+      setCompanyEditData(companyDocSnap.data());
+    };
+    getCompanyEditData();
+  }, []);
+  console.log(companyEditData);
   return (
     <FormControl>
       <MainContentContainer>

--- a/profit-system/src/components/organisms/form/CompanyEditForm.tsx
+++ b/profit-system/src/components/organisms/form/CompanyEditForm.tsx
@@ -5,34 +5,118 @@ import { MainContentContainer } from "../../molecules/container/MainContentConta
 import { PrimaryFormItem } from "../../molecules/item/PrimaryFormItem";
 import { PostNumFormItem } from "../../molecules/item/PostNumFormItem";
 import { PhoneFormItem } from "../../molecules/item/PhoneFormItem";
-import { useLocation } from "react-router-dom";
-import { DocumentData, doc, getDoc } from "firebase/firestore";
+import { useLocation, useNavigate } from "react-router-dom";
+import { doc, getDoc, updateDoc } from "firebase/firestore";
 import { db } from "../../../firebase";
 
 export const CompanyEditForm: FC = memo(() => {
+  const navigate = useNavigate();
   const location = useLocation();
-  const [companyEditData, setCompanyEditData] = useState<DocumentData>();
   const docId = location.state.docId;
-  console.log(docId);
-
   const companyDocRef = doc(db, "company", docId);
+  const [companyName, setCompanyName] = useState("");
+  const [companyAddress, setCompanyAddress] = useState("");
+  const [companyPostCode1, setCompanyPostCode1] = useState("");
+  const [companyPostCode2, setCompanyPostCode2] = useState("");
+  const [companyPhone1, setCompanyPhone1] = useState("");
+  const [companyPhone2, setCompanyPhone2] = useState("");
+  const [companyPhone3, setCompanyPhone3] = useState("");
+
   useEffect(() => {
     const getCompanyEditData = async () => {
       const companyDocSnap = await getDoc(companyDocRef);
-      console.log(companyDocSnap.data());
-      setCompanyEditData(companyDocSnap.data());
+      if (companyDocSnap.exists()) {
+        setCompanyName(companyDocSnap.data().name);
+        setCompanyAddress(companyDocSnap.data().address);
+        const postCode = companyDocSnap.data().postCode;
+        const postCode1 = postCode.split("-")[0];
+        const postCode2 = postCode.split("-")[1];
+        setCompanyPostCode1(postCode1);
+        setCompanyPostCode2(postCode2);
+        const phone = companyDocSnap.data().phone;
+        const phone1 = phone.split("-")[0];
+        const phone2 = phone.split("-")[1];
+        const phone3 = phone.split("-")[2];
+        setCompanyPhone1(phone1);
+        setCompanyPhone2(phone2);
+        setCompanyPhone3(phone3);
+      } else {
+        console.log("No such document!");
+      }
     };
     getCompanyEditData();
   }, []);
-  console.log(companyEditData);
+
+  const handleCompanyName = (newValue: string) => {
+    setCompanyName(newValue);
+  };
+  const handleCompanyAddress = (newValue: string) => {
+    setCompanyAddress(newValue);
+  };
+  const handleCompanyPostCode1 = (newValue: string) => {
+    setCompanyPostCode1(newValue);
+  };
+  const handleCompanyPostCode2 = (newValue: string) => {
+    setCompanyPostCode2(newValue);
+  };
+  const handleCompanyPhone1 = (newValue: string) => {
+    setCompanyPhone1(newValue);
+  };
+  const handleCompanyPhone2 = (newValue: string) => {
+    setCompanyPhone2(newValue);
+  };
+  const handleCompanyPhone3 = (newValue: string) => {
+    setCompanyPhone3(newValue);
+  };
+
+  const onClickEdit = async () => {
+    await updateDoc(companyDocRef, {
+      name: companyName,
+      postCode: `${companyPostCode1}-${companyPostCode2}`,
+      address: companyAddress,
+      phone: `${companyPhone1}-${companyPhone2}-${companyPhone3}`,
+    });
+    navigate("/companies_list");
+  };
+
+  const onClickBack = () => {
+    navigate("/companies_list");
+  };
+
   return (
     <FormControl>
       <MainContentContainer>
-        <PrimaryFormItem text="顧客名" />
-        <PostNumFormItem />
-        <PrimaryFormItem text="住所" />
-        <PhoneFormItem />
-        <FormButtonContainer primaryText="更新" secondaryPx="10" ml="50px" />
+        <PrimaryFormItem
+          text="顧客名"
+          value={companyName}
+          handleValueChange={handleCompanyName}
+        />
+        <PostNumFormItem
+          value1={companyPostCode1}
+          value2={companyPostCode2}
+          handleValueChange1={handleCompanyPostCode1}
+          handleValueChange2={handleCompanyPostCode2}
+        />
+        <PrimaryFormItem
+          text="住所"
+          value={companyAddress}
+          handleValueChange={handleCompanyAddress}
+        />
+        <PhoneFormItem
+          value1={companyPhone1}
+          value2={companyPhone2}
+          value3={companyPhone3}
+          handleValueChange1={handleCompanyPhone1}
+          handleValueChange2={handleCompanyPhone2}
+          handleValueChange3={handleCompanyPhone3}
+        />
+        <FormButtonContainer
+          primaryText="更新"
+          secondaryPx="10"
+          ml="50px"
+          primaryOnClick={onClickEdit}
+          secondaryOnClick={onClickBack}
+        />
       </MainContentContainer>
     </FormControl>
   );

--- a/profit-system/src/components/organisms/form/CompanyEditForm.tsx
+++ b/profit-system/src/components/organisms/form/CompanyEditForm.tsx
@@ -1,12 +1,12 @@
 import { FormControl } from "@chakra-ui/react";
-import { FC, memo, useEffect, useState } from "react";
+import { FC, memo, useState } from "react";
 import { FormButtonContainer } from "../../molecules/container/FormButtonContainer";
 import { MainContentContainer } from "../../molecules/container/MainContentContainer";
 import { PrimaryFormItem } from "../../molecules/item/PrimaryFormItem";
 import { PostNumFormItem } from "../../molecules/item/PostNumFormItem";
 import { PhoneFormItem } from "../../molecules/item/PhoneFormItem";
 import { useLocation, useNavigate } from "react-router-dom";
-import { doc, getDoc, updateDoc } from "firebase/firestore";
+import { doc, updateDoc } from "firebase/firestore";
 import { db } from "../../../firebase";
 
 export const CompanyEditForm: FC = memo(() => {
@@ -14,38 +14,19 @@ export const CompanyEditForm: FC = memo(() => {
   const location = useLocation();
   const docId = location.state.docId;
   const companyDocRef = doc(db, "company", docId);
-  const [companyName, setCompanyName] = useState("");
-  const [companyAddress, setCompanyAddress] = useState("");
-  const [companyPostCode1, setCompanyPostCode1] = useState("");
-  const [companyPostCode2, setCompanyPostCode2] = useState("");
-  const [companyPhone1, setCompanyPhone1] = useState("");
-  const [companyPhone2, setCompanyPhone2] = useState("");
-  const [companyPhone3, setCompanyPhone3] = useState("");
 
-  useEffect(() => {
-    const getCompanyEditData = async () => {
-      const companyDocSnap = await getDoc(companyDocRef);
-      if (companyDocSnap.exists()) {
-        setCompanyName(companyDocSnap.data().name);
-        setCompanyAddress(companyDocSnap.data().address);
-        const postCode = companyDocSnap.data().postCode;
-        const postCode1 = postCode.split("-")[0];
-        const postCode2 = postCode.split("-")[1];
-        setCompanyPostCode1(postCode1);
-        setCompanyPostCode2(postCode2);
-        const phone = companyDocSnap.data().phone;
-        const phone1 = phone.split("-")[0];
-        const phone2 = phone.split("-")[1];
-        const phone3 = phone.split("-")[2];
-        setCompanyPhone1(phone1);
-        setCompanyPhone2(phone2);
-        setCompanyPhone3(phone3);
-      } else {
-        console.log("No such document!");
-      }
-    };
-    getCompanyEditData();
-  }, []);
+  const [companyName, setCompanyName] = useState(location.state.name);
+  const [companyAddress, setCompanyAddress] = useState(location.state.address);
+  const postCode1 = location.state.postCode.split("-")[0];
+  const postCode2 = location.state.postCode.split("-")[1];
+  const [companyPostCode1, setCompanyPostCode1] = useState(postCode1);
+  const [companyPostCode2, setCompanyPostCode2] = useState(postCode2);
+  const phone1 = location.state.phone.split("-")[0];
+  const phone2 = location.state.phone.split("-")[1];
+  const phone3 = location.state.phone.split("-")[2];
+  const [companyPhone1, setCompanyPhone1] = useState(phone1);
+  const [companyPhone2, setCompanyPhone2] = useState(phone2);
+  const [companyPhone3, setCompanyPhone3] = useState(phone3);
 
   const handleCompanyName = (newValue: string) => {
     setCompanyName(newValue);

--- a/profit-system/src/components/organisms/form/CompanyRegisterForm.tsx
+++ b/profit-system/src/components/organisms/form/CompanyRegisterForm.tsx
@@ -48,7 +48,10 @@ export const CompanyRegisterForm: FC = memo(() => {
       address: companyAddress,
       phone: `${companyPhone1}-${companyPhone2}-${companyPhone3}`,
     });
+    navigate("/companies_list");
+  };
 
+  const onClickBack = () => {
     navigate("/companies_list");
   };
 
@@ -69,7 +72,8 @@ export const CompanyRegisterForm: FC = memo(() => {
         <FormButtonContainer
           secondaryPx="10"
           ml="50px"
-          onClick={onClickRegister}
+          primaryOnClick={onClickRegister}
+          secondaryOnClick={onClickBack}
         />
       </MainContentContainer>
     </FormControl>


### PR DESCRIPTION
## why
#31 

## what
- SecondaryButton.tsxにonClick propsを追加。
- onClickEdit関数を作成し、ボタン押下時に顧客編集画面へ遷移し、顧客の全情報をuseNavigateのステートとして渡します。
- 編集画面で`const docId = location.state.docId;`でドキュメントIDを取得。
- 目的の顧客情報を取得して編集可能。
- 更新ボタン押下時、更新内容はFirestoreのDBにも適応されています。

![UpdateCompanyDB](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/ed6895d2-4068-4c84-aafe-108e169357dd)

## related issues
close #n

