### PR TITLE
案件一覧画面にProjectテーブルのデータを表示する

### DIFF
--- a/profit-system/src/components/atoms/button/IconButton.tsx
+++ b/profit-system/src/components/atoms/button/IconButton.tsx
@@ -5,10 +5,11 @@ import { faUserPlus } from "@fortawesome/free-solid-svg-icons";
 
 type Props = {
   text: string;
+  onClick?: () => void;
 };
 
 export const IconButton: FC<Props> = memo((props) => {
-  const { text } = props;
+  const { text, onClick } = props;
   return (
     <Button
       bg="green.400"
@@ -19,6 +20,7 @@ export const IconButton: FC<Props> = memo((props) => {
       shadow="md"
       variant="outline"
       _hover={{ opacity: 0.8 }}
+      onClick={onClick}
     >
       <Text pr="8px">
         <FontAwesomeIcon icon={faUserPlus} />

--- a/profit-system/src/components/atoms/item/TableBodyItem.tsx
+++ b/profit-system/src/components/atoms/item/TableBodyItem.tsx
@@ -2,7 +2,7 @@ import { Td } from "@chakra-ui/react";
 import { FC } from "react";
 
 type Props = {
-  text: string;
+  text: string | number;
 };
 
 export const TableBodyItem: FC<Props> = (props) => {

--- a/profit-system/src/components/molecules/list/ProjectTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/ProjectTableTemplateList.tsx
@@ -3,8 +3,27 @@ import { memo, FC } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
+import { ProjectDbType } from "../../../types/project/ProjectDbType";
+import { useNavigate } from "react-router-dom";
 
-export const ProjectTableTemplateList: FC = memo(() => {
+type Props = {
+  projectList: ProjectDbType[];
+};
+
+export const ProjectTableTemplateList: FC<Props> = memo((props) => {
+  const navigate = useNavigate();
+  const { projectList } = props;
+
+  const onClickEdit = (docId: string, name: string, price: number) => {
+    navigate("/projects_list/project_edit", {
+      state: {
+        docId: docId,
+        name: name,
+        price: price,
+      },
+    });
+  };
+
   return (
     <TableContainer>
       <Table variant="simple">
@@ -17,16 +36,15 @@ export const ProjectTableTemplateList: FC = memo(() => {
         </Thead>
 
         <Tbody alignItems="center">
-          <Tr fontSize="14">
-            <TableBodyItem text="xxxx向けシステム開発" />
-            <TableBodyItem text="1,000,000円" />
-            <EditItem />
-          </Tr>
-          <Tr fontSize="14">
-            <TableBodyItem text="xxxx向けシステム開発" />
-            <TableBodyItem text="2,000,000円" />
-            <EditItem />
-          </Tr>
+          {projectList.map((data) => (
+            <Tr fontSize="14" key={data.id}>
+              <TableBodyItem text={data.name} />
+              <TableBodyItem text={`${data.price.toLocaleString()}円`} />
+              <EditItem
+                onClick={() => onClickEdit(data.id, data.name, data.price)}
+              />
+            </Tr>
+          ))}
         </Tbody>
       </Table>
     </TableContainer>

--- a/profit-system/src/components/pages/ProjectsList.tsx
+++ b/profit-system/src/components/pages/ProjectsList.tsx
@@ -1,24 +1,51 @@
 import { Box } from "@chakra-ui/react";
-import { memo, FC } from "react";
+import { memo, FC, useState, useEffect } from "react";
 import { HeadLine } from "../atoms/HeadLine";
 import { MainScreenTopContainer } from "../molecules/container/MainScreenTopContainer";
 import { ContentBgTemplate } from "../molecules/container/ContentBgTemplateContainer";
 import { PrimarySearchButton } from "../atoms/button/PrimarySearchButton";
 import { ProjectTableTemplateList } from "../molecules/list/ProjectTableTemplateList";
 import { IconButton } from "../atoms/button/IconButton";
+import { ProjectDbType } from "../../types/project/ProjectDbType";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../firebase";
+import { useNavigate } from "react-router-dom";
 
 export const ProjectsList: FC = memo(() => {
+  const navigate = useNavigate();
+  const [projectData, setProjectData] = useState<ProjectDbType[]>([]);
+
+  useEffect(() => {
+    const getProjectData = async () => {
+      const projectList: ProjectDbType[] = [];
+      const querySnapshot = await getDocs(collection(db, "project"));
+      querySnapshot.forEach((doc) => {
+        projectList.push({
+          id: doc.id,
+          name: doc.data().name,
+          price: doc.data().price,
+        });
+      });
+      setProjectData(projectList);
+    };
+    getProjectData();
+  }, []);
+
+  const onClickRegisterPage = () => {
+    navigate("/projects_list/project_register");
+  };
+
   return (
     <>
       <HeadLine text="案件一覧" />
       <MainScreenTopContainer>
         <PrimarySearchButton text="案件名" />
         <Box>
-          <IconButton text="案件を登録する" />
+          <IconButton text="案件を登録する" onClick={onClickRegisterPage} />
         </Box>
       </MainScreenTopContainer>
       <ContentBgTemplate>
-        <ProjectTableTemplateList />
+        <ProjectTableTemplateList projectList={projectData} />
       </ContentBgTemplate>
     </>
   );

--- a/profit-system/src/types/project/ProjectDbType.ts
+++ b/profit-system/src/types/project/ProjectDbType.ts
@@ -1,0 +1,5 @@
+export type ProjectDbType = {
+  id: string;
+  name: string;
+  price: number;
+};


### PR DESCRIPTION
## why
#32 

## what
- FirestoreのProjectコレクションから全案件情報を取得し、案件一覧画面に表示。
- 案件金額を登録する時にnumber型として登録しますのでカンマ無しの数字(2000000)を記入します。なので、案件一覧の表示のために数字をフォーマットして、次のように表示されます: 2,000,000円

![image](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/bc170bce-109e-4cec-a9fa-74f3daffc60b)

## related issues
close #n