### PR TITLE
ユーザ一覧画面にUsersテーブルのデータを表示する

### DIFF
--- a/profit-system/src/components/atoms/button/LoginButton.tsx
+++ b/profit-system/src/components/atoms/button/LoginButton.tsx
@@ -22,6 +22,8 @@ export const LoginButton: FC = memo(() => {
           const data = {
             id: uid,
             name: displayName,
+            workHourCost: 1000,
+            isAdmin: false,
           };
           await setDoc(doc(db, "users", uid), data);
         }

--- a/profit-system/src/components/molecules/list/UsersTableTemplateList.tsx
+++ b/profit-system/src/components/molecules/list/UsersTableTemplateList.tsx
@@ -3,15 +3,32 @@ import { memo, FC } from "react";
 import { TableHeadItem } from "../../atoms/item/TableHeadItem";
 import { TableBodyItem } from "../../atoms/item/TableBodyItem";
 import { EditItem } from "../EditItem";
+import { useNavigate } from "react-router-dom";
+import { UserDbType } from "../../../types/user/UserDbType";
 
-export const UsersTableTemplateList: FC = memo(() => {
-  const userData = [
-    { userName: "ユーザ 太郎", isAdmin: "投稿者", cost: "1,000円" },
-    { userName: "ユーザ 二郎", isAdmin: "投稿者", cost: "1,200円" },
-    { userName: "ユーザ 花子", isAdmin: "管理者", cost: "1,000円" },
-    { userName: "ユーザ 二郎", isAdmin: "投稿者", cost: "1,500円" },
-    { userName: "ユーザ 太郎", isAdmin: "投稿者", cost: "2,000円" },
-  ];
+type Props = {
+  userList: UserDbType[];
+};
+
+export const UsersTableTemplateList: FC<Props> = memo((props) => {
+  const navigate = useNavigate();
+  const { userList } = props;
+
+  const onClickEdit = (
+    id: string,
+    isAdmin: string,
+    name: string,
+    workHourCost: number
+  ) => {
+    navigate("/users_list/user_edit", {
+      state: {
+        id: id,
+        isAdmin: isAdmin,
+        name: name,
+        workHourCost: workHourCost,
+      },
+    });
+  };
 
   return (
     <TableContainer>
@@ -25,12 +42,21 @@ export const UsersTableTemplateList: FC = memo(() => {
           </Tr>
         </Thead>
         <Tbody alignItems="center">
-          {userData.map((user) => (
-            <Tr key={user.userName} fontSize="14">
-              <TableBodyItem text={user.userName} />
-              <TableBodyItem text={user.isAdmin} />
-              <TableBodyItem text={user.cost} />
-              <EditItem />
+          {userList.map((data) => (
+            <Tr key={data.id} fontSize="14">
+              <TableBodyItem text={data.name} />
+              <TableBodyItem text={data.isAdmin ? "管理者" : "投稿者"} />
+              <TableBodyItem text={`${data.workHourCost.toLocaleString()}円`} />
+              <EditItem
+                onClick={() => {
+                  onClickEdit(
+                    data.id,
+                    data.isAdmin ? "管理者" : "投稿者",
+                    data.name,
+                    data.workHourCost
+                  );
+                }}
+              />
             </Tr>
           ))}
         </Tbody>

--- a/profit-system/src/components/pages/UsersList.tsx
+++ b/profit-system/src/components/pages/UsersList.tsx
@@ -1,14 +1,36 @@
-import { FC, memo } from "react";
+import { FC, memo, useState, useEffect } from "react";
 import { HeadLine } from "../atoms/HeadLine";
 import { ContentBgTemplate } from "../molecules/container/ContentBgTemplateContainer";
 import { UsersTableTemplateList } from "../molecules/list/UsersTableTemplateList";
+import { UserDbType } from "../../types/user/UserDbType";
+import { collection, getDocs } from "firebase/firestore";
+import { db } from "../../firebase";
 
 export const UsersList: FC = memo(() => {
+  const [userData, setUserData] = useState<UserDbType[]>([]);
+
+  useEffect(() => {
+    const getUserData = async () => {
+      const userList: UserDbType[] = [];
+      const querySnapshot = await getDocs(collection(db, "users"));
+      querySnapshot.forEach((doc) => {
+        userList.push({
+          id: doc.data().id,
+          name: doc.data().name,
+          workHourCost: doc.data().workHourCost,
+          isAdmin: doc.data().isAdmin,
+        });
+      });
+      setUserData(userList);
+    };
+    getUserData();
+  }, []);
+
   return (
     <>
       <HeadLine text="ユーザ一覧" />
       <ContentBgTemplate>
-        <UsersTableTemplateList />
+        <UsersTableTemplateList userList={userData} />
       </ContentBgTemplate>
     </>
   );

--- a/profit-system/src/types/user/UserDbType.ts
+++ b/profit-system/src/types/user/UserDbType.ts
@@ -1,0 +1,6 @@
+export type UserDbType = {
+  id: string;
+  isAdmin: boolean;
+  name: string;
+  workHourCost: number;
+};


### PR DESCRIPTION
## why
#27 

## what
- ユーザードキュメントにデータ追加。（isAdmin (権限), workHourCost(作業コスト))
- ユーザー一覧画面にコレクションUsersの全ドキュメントが表示される。

![image](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/26ecfd9c-9f4c-4fde-b60b-46b9faddce27)


## related issues
close #n