### PR TITLE
工数登録画面の情報をLogテーブルに追加する機能を開発

### DIFF
--- a/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
+++ b/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
@@ -4,7 +4,7 @@ import { ProjectNameList } from "../../../types/project/ProjectNameList";
 
 type Props = {
   value?: string;
-  projectNameList: ProjectNameList[];
+  projectNameList?: ProjectNameList[];
   onChangeProject?: (value: string) => void;
 };
 
@@ -39,7 +39,7 @@ export const ProjectSelectForm: FC<Props> = memo((props) => {
         value={value}
         onChange={handleOnChangeProject}
       >
-        {projectNameList.map((data) => (
+        {projectNameList?.map((data) => (
           <option key={data.id} value={data.name}>
             {data.name}
           </option>

--- a/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
+++ b/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
@@ -1,16 +1,20 @@
 import { Divider, Flex, FormLabel, Select } from "@chakra-ui/react";
-import { ChangeEvent, FC, memo, useState } from "react";
+import { ChangeEvent, FC, memo } from "react";
+import { ProjectNameList } from "../../../types/project/ProjectNameList";
 
 type Props = {
   value?: string;
+  projectNameList: ProjectNameList[];
+  onChangeProject?: (value: string) => void;
 };
 
 export const ProjectSelectForm: FC<Props> = memo((props) => {
-  const { value } = props;
-  const [project, setProject] = useState(value);
+  const { value, projectNameList, onChangeProject } = props;
 
-  const onChangeProject = (e: ChangeEvent<HTMLSelectElement>) =>
-    setProject(e.target.value);
+  const handleOnChangeProject = (e: ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    onChangeProject?.(value);
+  };
 
   return (
     <>
@@ -32,12 +36,14 @@ export const ProjectSelectForm: FC<Props> = memo((props) => {
         w="75%"
         borderRadius="20px"
         placeholder="案件名を選択"
-        value={project}
-        onChange={onChangeProject}
+        value={value}
+        onChange={handleOnChangeProject}
       >
-        <option value="A向けシステム開発">A向けシステム開発</option>
-        <option value="B向けシステム開発">B向けシステム開発</option>
-        <option value="C向けシステム開発">C向けシステム開発</option>
+        {projectNameList.map((data) => (
+          <option key={data.id} value={data.name}>
+            {data.name}
+          </option>
+        ))}
       </Select>
     </>
   );

--- a/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
+++ b/profit-system/src/components/molecules/form/ProjectSelectForm.tsx
@@ -1,10 +1,10 @@
 import { Divider, Flex, FormLabel, Select } from "@chakra-ui/react";
 import { ChangeEvent, FC, memo } from "react";
-import { ProjectNameList } from "../../../types/project/ProjectNameList";
+import { ProjectNameListType } from "../../../types/project/ProjectNameListType";
 
 type Props = {
   value?: string;
-  projectNameList?: ProjectNameList[];
+  projectNameList?: ProjectNameListType[];
   onChangeProject?: (value: string) => void;
 };
 

--- a/profit-system/src/components/molecules/form/WorkhourSelectForm.tsx
+++ b/profit-system/src/components/molecules/form/WorkhourSelectForm.tsx
@@ -1,16 +1,18 @@
 import { Divider, Flex, FormLabel, Select } from "@chakra-ui/react";
-import { ChangeEvent, FC, memo, useState } from "react";
+import { ChangeEvent, FC, memo } from "react";
 
 type Props = {
-  value?: string;
+  value?: number;
+  onChangeWorkHour?: (value: string) => void;
 };
 
 export const WorkhourSelectForm: FC<Props> = memo((props) => {
-  const { value } = props;
-  const [hour, setHour] = useState(value);
+  const { value, onChangeWorkHour } = props;
 
-  const onChangeHour = (e: ChangeEvent<HTMLSelectElement>) =>
-    setHour(e.target.value);
+  const handleOnChangeHour = (e: ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    onChangeWorkHour?.(value);
+  };
 
   return (
     <>
@@ -32,8 +34,8 @@ export const WorkhourSelectForm: FC<Props> = memo((props) => {
         w="75%"
         borderRadius="20px"
         placeholder="作業時間を選択する"
-        value={hour}
-        onChange={onChangeHour}
+        value={value}
+        onChange={handleOnChangeHour}
       >
         <option value="0.25">0.25</option>
         <option value="0.5">0.5</option>

--- a/profit-system/src/components/organisms/form/WorkhourEditForm.tsx
+++ b/profit-system/src/components/organisms/form/WorkhourEditForm.tsx
@@ -18,7 +18,7 @@ export const WorkhourEditForm: FC = memo(() => {
         display="flex"
       >
         <ProjectSelectForm value="A向けシステム開発" />
-        <WorkhourSelectForm value="5" />
+        <WorkhourSelectForm value={5} />
         <FormButtonContainer secondaryPx="10" />
       </FormControl>
     </MainContentContainer>

--- a/profit-system/src/components/organisms/form/WorkhourRegisterForm.tsx
+++ b/profit-system/src/components/organisms/form/WorkhourRegisterForm.tsx
@@ -1,11 +1,65 @@
 import { FormControl } from "@chakra-ui/react";
-import { memo, FC } from "react";
+import { memo, FC, useEffect, useState } from "react";
 import { MainContentContainer } from "../../molecules/container/MainContentContainer";
 import { ProjectSelectForm } from "../../molecules/form/ProjectSelectForm";
 import { WorkhourSelectForm } from "../../molecules/form/WorkhourSelectForm";
 import { FormButtonContainer } from "../../molecules/container/FormButtonContainer";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth, db } from "../../../firebase";
+import { Timestamp, addDoc, collection, getDocs } from "firebase/firestore";
+import { useNavigate } from "react-router-dom";
+import { ProjectNameList } from "../../../types/project/ProjectNameList";
 
 export const WorkhourRegisterForm: FC = memo(() => {
+  const navigate = useNavigate();
+  const today = Timestamp.fromDate(new Date());
+  const [userName, setUserName] = useState<string | null>("");
+  const [inChargeProject, setInChargeProject] = useState("");
+  const [workHour, setWorkHour] = useState(0);
+  const [projectNameList, setProjectNameList] = useState<ProjectNameList[]>([]);
+
+  const handleChargeProject = (value: string) => {
+    setInChargeProject(value);
+  };
+
+  const handleWorkHour = (value: string) => {
+    setWorkHour(Number(value));
+  };
+
+  useEffect(() => {
+    onAuthStateChanged(auth, (user) => {
+      if (user) {
+        setUserName(user.displayName);
+      }
+    });
+    const getProjectNameData = async () => {
+      const projectList: ProjectNameList[] = [];
+      const querySnapshot = await getDocs(collection(db, "project"));
+      querySnapshot.forEach((doc) => {
+        projectList.push({
+          id: doc.id,
+          name: doc.data().name,
+        });
+      });
+      setProjectNameList(projectList);
+    };
+    getProjectNameData();
+  }, []);
+
+  const onClickRegister = async () => {
+    await addDoc(collection(db, "log"), {
+      name: userName,
+      inChargeProject: inChargeProject,
+      workDay: today,
+      workHours: workHour,
+    });
+    onClickBack();
+  };
+
+  const onClickBack = () => {
+    navigate("/log");
+  };
+
   return (
     <MainContentContainer>
       <FormControl
@@ -17,9 +71,19 @@ export const WorkhourRegisterForm: FC = memo(() => {
         flexDirection="column"
         display="flex"
       >
-        <ProjectSelectForm />
-        <WorkhourSelectForm />
-        <FormButtonContainer secondaryPx="10" />
+        <ProjectSelectForm
+          projectNameList={projectNameList}
+          onChangeProject={handleChargeProject}
+        />
+        <WorkhourSelectForm
+          onChangeWorkHour={handleWorkHour}
+          value={workHour}
+        />
+        <FormButtonContainer
+          secondaryPx="10"
+          primaryOnClick={onClickRegister}
+          secondaryOnClick={onClickBack}
+        />
       </FormControl>
     </MainContentContainer>
   );

--- a/profit-system/src/components/organisms/form/WorkhourRegisterForm.tsx
+++ b/profit-system/src/components/organisms/form/WorkhourRegisterForm.tsx
@@ -8,7 +8,7 @@ import { onAuthStateChanged } from "firebase/auth";
 import { auth, db } from "../../../firebase";
 import { Timestamp, addDoc, collection, getDocs } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
-import { ProjectNameList } from "../../../types/project/ProjectNameList";
+import { ProjectNameListType } from "../../../types/project/ProjectNameListType";
 
 export const WorkhourRegisterForm: FC = memo(() => {
   const navigate = useNavigate();
@@ -16,7 +16,9 @@ export const WorkhourRegisterForm: FC = memo(() => {
   const [userName, setUserName] = useState<string | null>("");
   const [inChargeProject, setInChargeProject] = useState("");
   const [workHour, setWorkHour] = useState(0);
-  const [projectNameList, setProjectNameList] = useState<ProjectNameList[]>([]);
+  const [projectNameList, setProjectNameList] = useState<ProjectNameListType[]>(
+    []
+  );
 
   const handleChargeProject = (value: string) => {
     setInChargeProject(value);
@@ -33,7 +35,7 @@ export const WorkhourRegisterForm: FC = memo(() => {
       }
     });
     const getProjectNameData = async () => {
-      const projectList: ProjectNameList[] = [];
+      const projectList: ProjectNameListType[] = [];
       const querySnapshot = await getDocs(collection(db, "project"));
       querySnapshot.forEach((doc) => {
         projectList.push({

--- a/profit-system/src/types/project/ProjectNameList.ts
+++ b/profit-system/src/types/project/ProjectNameList.ts
@@ -1,4 +1,0 @@
-export type ProjectNameList = {
-  id: string;
-  name: string;
-};

--- a/profit-system/src/types/project/ProjectNameList.ts
+++ b/profit-system/src/types/project/ProjectNameList.ts
@@ -1,0 +1,4 @@
+export type ProjectNameList = {
+  id: string;
+  name: string;
+};

--- a/profit-system/src/types/project/ProjectNameListType.ts
+++ b/profit-system/src/types/project/ProjectNameListType.ts
@@ -1,0 +1,4 @@
+export type ProjectNameListType = {
+  id: string;
+  name: string;
+};


### PR DESCRIPTION
## why
#25 

## what
- Projectコレクションから全案件名の情報を取得、工数登録の案件を選択するSelectコンポーネントに使用。
- 工数登録ボタン押下時に、現在の日付を取得し、Firestoreの`Timestamp`データとして登録。

![WorkhourRegister](https://github.com/I-BIS-company/profitSystem_ibis/assets/132991861/50f03904-320a-4ade-b4b1-b1fa585cd75f)

## related issues
close #n